### PR TITLE
modify paddle infer benchmark log

### DIFF
--- a/tools/infer/benchmark_utils.py
+++ b/tools/infer/benchmark_utils.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import time
+import logging
+
+import paddle
+import paddle.inference as paddle_infer
+
+from pathlib import Path
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+LOG_PATH_ROOT = f"{CUR_DIR}/../../tools/output"
+
+
+class PaddleInferBenchmark(object):
+    def __init__(self,
+                 config,
+                 model_info: dict,
+                 data_info: dict,
+                 perf_info: dict,
+                 mem_info: dict,
+                 **kwargs):
+        """
+        Construct PaddleInferBenchmark Class to format logs.
+        args:
+            config(paddle.inference.Config): paddle inference config
+            model_info(dict): basic model info
+            data_info(dict): input data info
+            perf_info(dict): speed performance
+            mem_info(dict): cpu and gpu resources
+        """
+        # PaddleInferBenchmark Log Version
+        self.log_version = 1.0
+
+        # Paddle Version
+        self.paddle_version = paddle.__version__
+        self.paddle_commit = paddle.__git_commit__
+        paddle_infer_info = paddle_infer.get_version()
+        self.paddle_branch = paddle_infer_info.strip().split(': ')[-1]
+
+        # model info
+        self.model_info = model_info
+        self.model_name = model_info['model_name']
+        self.precision = model_info['precision']
+
+        # data info
+        self.data_info = data_info
+        self.batch_size = data_info['batch_size']
+        self.shape = data_info['shape']
+        self.data_num = data_info['data_num']
+
+        # conf info
+        self.config_status = self.parse_config(config)
+
+        # perf info
+        self.perf_info = perf_info
+        self.preprocess_time = round(perf_info['preprocess_time'], 4)
+        self.inference_time = round(perf_info['inference_time'], 4)
+        self.postprocess_time = round(perf_info['postprocess_time'], 4)
+        self.total_time = round(perf_info['total_time'], 4)
+
+        # mem info
+        self.mem_info = mem_info
+        if mem_info:
+            self.cpu_rss = int(mem_info['cpu_rss'])
+            self.gpu_rss = int(mem_info['gpu_rss'])
+            self.gpu_util = round(mem_info['gpu_util'], 2)
+        else:
+            self.cpu_rss = None
+            self.gpu_rss = None
+            self.gpu_util = None
+
+        # init benchmark logger
+        self.benchmark_logger()
+
+    def benchmark_logger(self):
+        """
+        benchmark logger
+        """
+        # Init logger
+        FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        log_output = f"{LOG_PATH_ROOT}/{self.model_name}.log"
+        Path(f"{LOG_PATH_ROOT}").mkdir(parents=True, exist_ok=True)
+        logging.basicConfig(
+            level=logging.INFO,
+            format=FORMAT,
+            handlers=[
+                logging.FileHandler(
+                    filename=log_output, mode='w'),
+                logging.StreamHandler(),
+            ])
+        self.logger = logging.getLogger(__name__)
+        self.logger.info(
+            f"Paddle Inference benchmark log will be saved to {log_output}")
+
+    def parse_config(self, config) -> dict:
+        """
+        parse paddle predictor config
+        args:
+            config(paddle.inference.Config): paddle inference config
+        return:
+            config_status(dict): dict style config info
+        """
+        config_status = {}
+        config_status['runtime_device'] = "gpu" if config.use_gpu() else "cpu"
+        config_status['ir_optim'] = config.ir_optim()
+        config_status['enable_tensorrt'] = config.tensorrt_engine_enabled()
+        config_status['precision'] = self.precision
+        config_status['enable_mkldnn'] = config.mkldnn_enabled()
+        config_status[
+            'cpu_math_library_num_threads'] = config.cpu_math_library_num_threads(
+            )
+        return config_status
+
+    def report(self, identifier=None):
+        """
+        print log report
+        args:
+            identifier(string): identify log
+        """
+        if identifier:
+            identifier = f"[{identifier}]"
+        else:
+            identifier = ""
+
+        self.logger.info("\n")
+        self.logger.info(
+            "---------------------- Paddle info ----------------------")
+        self.logger.info(f"{identifier} paddle_version: {self.paddle_version}")
+        self.logger.info(f"{identifier} paddle_commit: {self.paddle_commit}")
+        self.logger.info(f"{identifier} paddle_branch: {self.paddle_branch}")
+        self.logger.info(f"{identifier} log_style_version: {self.log_version}")
+        self.logger.info(
+            "----------------------- Conf info -----------------------")
+        self.logger.info(
+            f"{identifier} runtime_device: {self.config_status['runtime_device']}"
+        )
+        self.logger.info(
+            f"{identifier} ir_optim: {self.config_status['ir_optim']}")
+        self.logger.info(f"{identifier} enable_memory_optim: {True}")
+        self.logger.info(
+            f"{identifier} enable_tensorrt: {self.config_status['enable_tensorrt']}"
+        )
+        self.logger.info(f"{identifier} precision: {self.precision}")
+        self.logger.info(
+            f"{identifier} enable_mkldnn: {self.config_status['enable_mkldnn']}")
+        self.logger.info(
+            f"{identifier} cpu_math_library_num_threads: {self.config_status['cpu_math_library_num_threads']}"
+        )
+        self.logger.info(
+            "----------------------- Model info ----------------------")
+        self.logger.info(f"{identifier} model_name: {self.model_name}")
+        self.logger.info(
+            "----------------------- Data info -----------------------")
+        self.logger.info(f"{identifier} batch_size: {self.batch_size}")
+        self.logger.info(f"{identifier} input_shape: {self.shape}")
+        self.logger.info(f"{identifier} data_num: {self.data_num}")
+        self.logger.info(
+            "----------------------- Perf info -----------------------")
+        self.logger.info(
+            f"{identifier} cpu_rss(MB): {self.cpu_rss}, gpu_rss(MB): {self.gpu_rss}, gpu_util: {self.gpu_util}%"
+        )
+        self.logger.info(f"{identifier} total time spent(s): {self.total_time}")
+        self.logger.info(
+            f"{identifier} preproce_time(ms): {round(self.preprocess_time*1000, 1)}, inference_time(ms): {round(self.inference_time*1000, 1)}, postprocess_time(ms): {round(self.postprocess_time*1000, 1)}"
+        )
+
+    def print_help(self):
+        """
+        print function help
+        """
+        self.logger.info("""Usage: 
+            Print inference benchmark logs.
+            log = PaddleInferBenchmark(config, model_name, batch_size, shape, precision, times, mem_info)
+            log()
+            """)
+
+    def __call__(self, identifier=None):
+        """
+        __call__
+        args:
+            identifier(string): identify log
+        """
+        self.report(identifier)

--- a/tools/infer/benchmark_utils.py
+++ b/tools/infer/benchmark_utils.py
@@ -195,7 +195,7 @@ class PaddleInferBenchmark(object):
         )
         self.logger.info(f"{identifier} total time spent(s): {self.total_time_s}")
         self.logger.info(
-            f"{identifier} preproce_time(ms): {round(self.preprocess_time_s*1000, 1)}, inference_time(ms): {round(self.inference_time_s*1000, 1)}, postprocess_time(ms): {round(self.postprocess_time_s*1000, 1)}"
+            f"{identifier} preprocess_time(ms): {round(self.preprocess_time_s*1000, 1)}, inference_time(ms): {round(self.inference_time_s*1000, 1)}, postprocess_time(ms): {round(self.postprocess_time_s*1000, 1)}"
         )
 
     def print_help(self):

--- a/tools/infer/predict_det.py
+++ b/tools/infer/predict_det.py
@@ -248,8 +248,8 @@ if __name__ == "__main__":
     # print the information about memory and time-spent
     if args.benchmark:
         mems = {
-            'cpu_rss': cpu_mem / count,
-            'gpu_rss': gpu_mem / count,
+            'cpu_rss_mb': cpu_mem / count,
+            'gpu_rss_mb': gpu_mem / count,
             'gpu_util': gpu_util * 100 / count
         }
     else:
@@ -269,10 +269,10 @@ if __name__ == "__main__":
         'data_num': det_time_dict['img_num']
     }
     perf_info = {
-        'preprocess_time': det_time_dict['preprocess_time'],
-        'inference_time': det_time_dict['inference_time'],
-        'postprocess_time': det_time_dict['postprocess_time'],
-        'total_time': det_time_dict['total_time']
+        'preprocess_time_s': det_time_dict['preprocess_time'],
+        'inference_time_s': det_time_dict['inference_time'],
+        'postprocess_time_s': det_time_dict['postprocess_time'],
+        'total_time_s': det_time_dict['total_time']
     }
     benchmark_log = benchmark_utils.PaddleInferBenchmark(
         text_detector.config, model_info, data_info, perf_info, mems)

--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -62,7 +62,7 @@ class TextRecognizer(object):
                 "use_space_char": args.use_space_char
             }
         self.postprocess_op = build_post_process(postprocess_params)
-        self.predictor, self.input_tensor, self.output_tensors = \
+        self.predictor, self.input_tensor, self.output_tensors, self.config = \
             utility.create_predictor(args, 'rec', logger)
 
         self.rec_times = utility.Timer()
@@ -304,8 +304,26 @@ def main(args):
     logger.info("The predict time about recognizer module is as follows: ")
     rec_time_dict = text_recognizer.rec_times.report(average=True)
     rec_model_name = args.rec_model_dir
-    rec_logger = utility.LoggerHelper(args, rec_time_dict, rec_model_name, mems)
-    rec_logger.report("Rec")
+
+    # construct log information
+    model_info = {
+        'model_name': args.rec_model_dir.split('/')[-1],
+        'precision': args.precision
+    }
+    data_info = {
+        'batch_size': args.rec_batch_num,
+        'shape': 'dynamic_shape',
+        'data_num': rec_time_dict['img_num']
+    }
+    perf_info = {
+        'preprocess_time': rec_time_dict['preprocess_time'],
+        'inference_time': rec_time_dict['inference_time'],
+        'postprocess_time': rec_time_dict['postprocess_time'],
+        'total_time': rec_time_dict['total_time']
+    }
+    benchmark_log = benchmark_utils.PaddleInferBenchmark(
+        text_recognizer.config, model_info, data_info, perf_info, mems)
+    benchmark_log("Rec")
 
 
 if __name__ == "__main__":

--- a/tools/infer/predict_rec.py
+++ b/tools/infer/predict_rec.py
@@ -295,8 +295,8 @@ def main(args):
                                                rec_res[ino]))
     if args.benchmark:
         mems = {
-            'cpu_rss': cpu_mem / count,
-            'gpu_rss': gpu_mem / count,
+            'cpu_rss_mb': cpu_mem / count,
+            'gpu_rss_mb': gpu_mem / count,
             'gpu_util': gpu_util * 100 / count
         }
     else:
@@ -316,10 +316,10 @@ def main(args):
         'data_num': rec_time_dict['img_num']
     }
     perf_info = {
-        'preprocess_time': rec_time_dict['preprocess_time'],
-        'inference_time': rec_time_dict['inference_time'],
-        'postprocess_time': rec_time_dict['postprocess_time'],
-        'total_time': rec_time_dict['total_time']
+        'preprocess_time_s': rec_time_dict['preprocess_time'],
+        'inference_time_s': rec_time_dict['inference_time'],
+        'postprocess_time_s': rec_time_dict['postprocess_time'],
+        'total_time_s': rec_time_dict['total_time']
     }
     benchmark_log = benchmark_utils.PaddleInferBenchmark(
         text_recognizer.config, model_info, data_info, perf_info, mems)

--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -226,10 +226,46 @@ def main(args):
     #         det_time_dict[k] += rec_time_dict[k]
     det_model_name = args.det_model_dir
     rec_model_name = args.rec_model_dir
-    det_logger = utility.LoggerHelper(args, det_time_dict, det_model_name, mems)
-    rec_logger = utility.LoggerHelper(args, rec_time_dict, rec_model_name, mems)
-    det_logger.report("Det")
-    rec_logger.report("Rec")
+
+    # construct log information
+    model_info = {
+        'model_name': args.det_model_dir.split('/')[-1],
+        'precision': args.precision
+    }
+    data_info = {
+        'batch_size': 1,
+        'shape': 'dynamic_shape',
+        'data_num': det_time_dict['img_num']
+    }
+    perf_info = {
+        'preprocess_time': det_time_dict['preprocess_time'],
+        'inference_time': det_time_dict['inference_time'],
+        'postprocess_time': det_time_dict['postprocess_time'],
+        'total_time': det_time_dict['total_time']
+    }
+    benchmark_log = benchmark_utils.PaddleInferBenchmark(
+        text_detector.config, model_info, data_info, perf_info, mems)
+    benchmark_log("Det")
+
+    # construct log information
+    model_info = {
+        'model_name': args.rec_model_dir.split('/')[-1],
+        'precision': args.precision
+    }
+    data_info = {
+        'batch_size': args.rec_batch_num,
+        'shape': 'dynamic_shape',
+        'data_num': rec_time_dict['img_num']
+    }
+    perf_info = {
+        'preprocess_time': rec_time_dict['preprocess_time'],
+        'inference_time': rec_time_dict['inference_time'],
+        'postprocess_time': rec_time_dict['postprocess_time'],
+        'total_time': rec_time_dict['total_time']
+    }
+    benchmark_log = benchmark_utils.PaddleInferBenchmark(
+        text_recognizer.config, model_info, data_info, perf_info, mems)
+    benchmark_log("Rec")
 
 
 if __name__ == "__main__":

--- a/tools/infer/predict_system.py
+++ b/tools/infer/predict_system.py
@@ -213,8 +213,8 @@ def main(args):
     img_num = text_sys.text_detector.det_times.img_num
     if args.benchmark:
         mems = {
-            'cpu_rss': cpu_mem / count,
-            'gpu_rss': gpu_mem / count,
+            'cpu_rss_mb': cpu_mem / count,
+            'gpu_rss_mb': gpu_mem / count,
             'gpu_util': gpu_util * 100 / count
         }
     else:
@@ -238,10 +238,10 @@ def main(args):
         'data_num': det_time_dict['img_num']
     }
     perf_info = {
-        'preprocess_time': det_time_dict['preprocess_time'],
-        'inference_time': det_time_dict['inference_time'],
-        'postprocess_time': det_time_dict['postprocess_time'],
-        'total_time': det_time_dict['total_time']
+        'preprocess_time_s': det_time_dict['preprocess_time'],
+        'inference_time_s': det_time_dict['inference_time'],
+        'postprocess_time_s': det_time_dict['postprocess_time'],
+        'total_time_s': det_time_dict['total_time']
     }
     benchmark_log = benchmark_utils.PaddleInferBenchmark(
         text_detector.config, model_info, data_info, perf_info, mems)
@@ -258,9 +258,9 @@ def main(args):
         'data_num': rec_time_dict['img_num']
     }
     perf_info = {
-        'preprocess_time': rec_time_dict['preprocess_time'],
-        'inference_time': rec_time_dict['inference_time'],
-        'postprocess_time': rec_time_dict['postprocess_time'],
+        'preprocess_time_s': rec_time_dict['preprocess_time'],
+        'inference_time_s': rec_time_dict['inference_time'],
+        'postprocess_time_s': rec_time_dict['postprocess_time'],
         'total_time': rec_time_dict['total_time']
     }
     benchmark_log = benchmark_utils.PaddleInferBenchmark(

--- a/tools/infer_benchmark.sh
+++ b/tools/infer_benchmark.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+enable_mkldnn=False
+use_gpu=True
+cpu_threads=1
+use_trt=False
+precision='fp32'
+
+det_model_dir="./inference/ch_ppocr_mobile_v2.0_det_infer"
+img_dir="./doc/imgs/"
+rec_model_dir="./inference/ch_ppocr_mobile_v2.0_rec_infer"
+rec_img_dir="./doc/imgs/"
+
+benchmark=True
+
+# det
+python tools/infer/predict_det.py --enable_mkldnn=${enable_mkldnn} \
+                                  --use_gpu=${use_gpu} \
+                                  --cpu_threads=${cpu_threads} \
+                                  --use_tensorrt=${use_trt} \
+                                  --precision=${precision} \
+                                  --det_model_dir=${det_model_dir} \
+                                  --image_dir=${img_dir} \
+                                  --benchmark=${benchmark}
+
+# rec
+python tools/infer/predict_rec.py --enable_mkldnn=${enable_mkldnn} \
+                                  --use_gpu=${use_gpu} \
+                                  --cpu_threads=${cpu_threads} \
+                                  --use_tensorrt=${use_trt} \
+                                  --precision=${precision} \
+                                  --rec_batch_num=1 \
+                                  --rec_model_dir=${rec_model_dir} \
+                                  --image_dir=${rec_img_dir} \
+                                  --benchmark=True


### PR DESCRIPTION
1. `benchmark_utils.py` 是python预测日志文件，会手动放到各个模型repo的 `tools/infer/benchmark_utils.py` 位置。（考虑了几种api的嵌入方式，都不合理，使用起来反而更麻烦）。产出的日志会自动生成到 `tools/output/${model_name}` 下
2. `infer_benchmark.sh` 是Inference测试启动脚本，在各个repo里手动添加到 `tools/infer_benchmark.sh` 里。可以直接执行脚本测试部分模型配置。后续将可变参数作为input传入

TODO:
1. 显存内存的监控，改成另起线程监控


日志生成的参考样式如下
```shell
Paddle Inference benchmark log will be saved to /workspace/tools/infer/../../tools/output/ch_det_mv3_db_v2.0.log
---------------------- Paddle info ----------------------
[Det] paddle_version: 0.0.0
[Det] paddle_commit: 70e0e3d53f7375bd17fb8b9dd6ba0802990800ae
[Det] paddle_branch: release/2.1
[Det] log_style_version: 1.0
----------------------- Conf info -----------------------
[Det] runtime_device: gpu
[Det] ir_optim: True
[Det] enable_memory_optim: True
[Det] enable_tensorrt: False
[Det] precision: fp32
[Det] enable_mkldnn: False
[Det] cpu_math_library_num_threads: 1
----------------------- Model info ----------------------
[Det] model_name: ch_det_mv3_db_v2.0
----------------------- Data info -----------------------
[Det] batch_size: 1
[Det] input_shape: dynamic_shape
[Det] data_num: 29
----------------------- Perf info -----------------------
[Det] cpu_rss(MB): None, gpu_rss(MB): None, gpu_util: None%
[Det] total time spent(s): 7.3376
[Det] preproce_time(ms): 22.1, inference_time(ms): 85.4, postprocess_time(ms): 145.5
```
![image](https://user-images.githubusercontent.com/14963836/118230629-8ef3e080-b4c0-11eb-813f-a06ab0d4d805.png)

